### PR TITLE
ci: add snyk license scanning to PR CI workflow [test-only]

### DIFF
--- a/.github/actions/snyk-test/action.yaml
+++ b/.github/actions/snyk-test/action.yaml
@@ -1,0 +1,38 @@
+name: 'Run Snyk Test'
+description: 'Run tests with synk test'
+
+inputs:
+  token:
+    description: 'Snyk Token'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: snyk/actions/setup@cdb760004ba9ea4d525f2e043745dfe85bb9077e
+
+    - name: Set environment variable
+      run: echo "PATH=${PATH}:/root/.local/bin" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Run Snyk Test
+      continue-on-error: true
+      env:
+        SNYK_TOKEN: ${{ inputs.token }}
+      run: |
+        echo "::group::Running synk test ..."
+        pipx install pip-tools
+        source ~/.bashrc
+        python -m venv venv-test
+        source ./venv-test/bin/activate
+        pip-compile pyproject.toml -o requirements.txt
+        pip install -r requirements.txt
+        snyk test --file=requirements.txt
+        echo "::endgroup::"
+      shell: bash
+
+    - name: Cleanup
+      run: |
+        rm requirements.txt
+        rm -rf ./venv-test
+      shell: bash

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -211,3 +211,31 @@ jobs:
       timeout-minutes: 5
       env:
        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  snyk:
+    if: ${{ (github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url && github.triggering_actor != 'dependabot[bot]' ) }}
+    runs-on: ubuntu-latest
+    needs: [ set-versions ]
+    steps:
+      - name: Don't mess with line endings
+        run: |
+          git config --global core.autocrlf false
+      - name: Don't mess with line endings
+        run: |
+          git config --global core.autocrlf false
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: ${{ needs.set-versions.outputs.max }}
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/pip
+          key: ubuntu-latest-${{ needs.set-versions.outputs.max }}-pip-${{ hashFiles('setup.cfg') }}
+          restore-keys: |
+            ubuntu-latest-${{ needs.set-versions.outputs.max }}-pip-
+      - uses: ./.github/actions/snyk-test
+        with:
+          token: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
Current snyk scans with pyproject.toml are only supported with poetry. This solution installs dependencies into a virtual environment and generates a temporary requirements.txt for scanning.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Hot fix (emergency fix and release)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (change which affects the documentation site)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Release (`develop` -> `main`)

## Quality assurance (all should be covered).

- [ ] My code follows the code style of this project.
- [ ] Documentation for my change is up to date?
- [ ] My PR meets testing requirements.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

<!--- Uncomment below if changes are for GitHub Actions -->

<!--
### How To Test

If using [act](https://github.com/nektos/act), fill in below:

**act version**  

**act command**
```bash
```
-->

## Summary

## Key links:

- [Sonar coverage](https://sonarcloud.io/dashboard?id=compliance-trestle)

# Before you merge

- Ensure it is a 'squash commit' if not a release.
- Ensure CI is currently passing
- Check sonar. If you are working for a fork a maintainer will reach out, if required.
